### PR TITLE
Condition for access_token attribute

### DIFF
--- a/lib/ok_ru.js
+++ b/lib/ok_ru.js
@@ -33,7 +33,6 @@ OkApi = (function() {
   makeRequest = function(method, postData, callback) {
     var getUrl, requestedData;
     requestedData = {
-      access_token: requestOptions['accessToken'],
       application_key: requestOptions['applicationKey'],
       sig: okSignature(postData)
     };

--- a/lib/ok_ru.js
+++ b/lib/ok_ru.js
@@ -37,6 +37,9 @@ OkApi = (function() {
       application_key: requestOptions['applicationKey'],
       sig: okSignature(postData)
     };
+    if (requestOptions['accessToken'] != null && requestOptions['accessToken'] !== '') {
+      requestedData.access_token = requestOptions['accessToken'];
+    }
     _.extend(requestedData, postData);
     switch (method.toUpperCase()) {
       case 'POST':

--- a/src/ok_ru.coffee
+++ b/src/ok_ru.coffee
@@ -39,7 +39,6 @@ class OkApi
 
   makeRequest = (method, postData, callback) ->
     requestedData =
-      access_token: requestOptions['accessToken']
       application_key: requestOptions['applicationKey']
       sig: okSignature(postData)
       

--- a/src/ok_ru.coffee
+++ b/src/ok_ru.coffee
@@ -42,7 +42,11 @@ class OkApi
       access_token: requestOptions['accessToken']
       application_key: requestOptions['applicationKey']
       sig: okSignature(postData)
-
+      
+    # use access_token if presented only
+    if requestOptions['accessToken']? and requestOptions['accessToken'] isnt ''
+      requestedData.access_token = requestOptions['accessToken'];
+    
     _.extend(requestedData, postData)
 
     switch method.toUpperCase()


### PR DESCRIPTION
For some requests, the attribute access_token may not be passed. If client\user don't passed accessToken in requestOptions it don't include in result REST request.